### PR TITLE
Added "change_log_level" handling to enable log level changes

### DIFF
--- a/vyked/bus.py
+++ b/vyked/bus.py
@@ -214,11 +214,21 @@ class TCPBus:
                                            'http')
 
     def _handle_log_change(self, packet, protocol):
-        level = packet['level'].upper()
+        try:
+            level = getattr(logging, packet['level'].upper())
+        except KeyError as e:
+            self._logger.error(e)
+            protocol.send('Malformed packet')
+            return
+        except AttributeError as e:
+            self._logger.error(e)
+            protocol.send('Allowed logging levels: DEBUG, INFO, WARNING, ERROR, CRITICAL')
+            return
         logging.getLogger().setLevel(level)
         for handler in logging.getLogger().handlers:
             handler.setLevel(level)
-        protocol.send('Done')
+        protocol.send('Logging level updated')
+
 
 class PubSubBus:
     PUBSUB_DELAY = 5

--- a/vyked/bus.py
+++ b/vyked/bus.py
@@ -171,6 +171,8 @@ class TCPBus:
             self._handle_pong(packet['node_id'], packet['count'])
         elif packet['type'] == 'publish':
             self._handle_publish(packet, protocol)
+        elif packet['type'] == 'change_log_level':
+            self._handle_log_change(packet, protocol)
         else:
             if self.tcp_host.is_for_me(packet['service'], packet['version']):
                 func = getattr(self, '_' + packet['type'] + '_receiver')
@@ -211,6 +213,12 @@ class TCPBus:
                                            self.http_host.version, self.http_host.node_id, self.http_host.clients,
                                            'http')
 
+    def _handle_log_change(self, packet, protocol):
+        level = packet['level'].upper()
+        logging.getLogger().setLevel(level)
+        for handler in logging.getLogger().handlers:
+            handler.setLevel(level)
+        protocol.send('Done')
 
 class PubSubBus:
     PUBSUB_DELAY = 5

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -361,11 +361,20 @@ class Registry:
         asyncio.get_event_loop().call_later(300, self.periodic_uptime_logger)
 
     def _handle_log_change(self, packet, protocol):
-        level = packet['level'].upper()
+        try:
+            level = getattr(logging, packet['level'].upper())
+        except KeyError as e:
+            self.logger.error(e)
+            protocol.send('Malformed packet')
+            return
+        except AttributeError as e:
+            self.logger.error(e)
+            protocol.send('Allowed logging levels: DEBUG, INFO, WARNING, ERROR, CRITICAL')
+            return
         logging.getLogger().setLevel(level)
         for handler in logging.getLogger().handlers:
             handler.setLevel(level)
-        protocol.send('Done')
+        protocol.send('Logging level updated')
 
 
 if __name__ == '__main__':

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -218,6 +218,8 @@ class Registry:
             self._pong(packet, protocol)
         elif request_type == 'uptime_report':
             self._get_uptime_report(packet, protocol)
+        elif request_type == 'change_log_level':
+            self._handle_log_change(packet, protocol)
 
     def deregister_service(self, host, port, node_id):
         service = self._repository.get_node(node_id)
@@ -357,6 +359,13 @@ class Registry:
     def periodic_uptime_logger(self):
         self._repository.log_uptimes()
         asyncio.get_event_loop().call_later(300, self.periodic_uptime_logger)
+
+    def _handle_log_change(self, packet, protocol):
+        level = packet['level'].upper()
+        logging.getLogger().setLevel(level)
+        for handler in logging.getLogger().handlers:
+            handler.setLevel(level)
+        protocol.send('Done')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added "change_log_level" handling to enable log level changes at runtime. Code duplication can be resolved by moving handler to jsonprotocol or re-writing registry as a famous TCP service. 
