### PR TITLE
x-subscribe fix

### DIFF
--- a/vyked/bus.py
+++ b/vyked/bus.py
@@ -224,7 +224,6 @@ class PubSubBus:
         self._pubsub_handler = None
         self._registry_client = registry_client
         self._clients = None
-        self._pending_publishes = {}
         self._ssl_context = ssl_context
 
     def create_pubsub_handler(self, host, port):

--- a/vyked/bus.py
+++ b/vyked/bus.py
@@ -169,8 +169,6 @@ class TCPBus:
             self._handle_ping(packet, protocol)
         elif packet['type'] == 'pong':
             self._handle_pong(packet['node_id'], packet['count'])
-        elif packet['type'] == 'publish':
-            self._handle_publish(packet, protocol)
         elif packet['type'] == 'change_log_level':
             self._handle_log_change(packet, protocol)
         else:
@@ -194,15 +192,6 @@ class TCPBus:
             future.add_done_callback(send_result)
         else:
             print('no api found for packet: ', packet)
-
-    def _handle_publish(self, packet, protocol):
-        service, version, endpoint, payload, publish_id = (packet['service'], packet['version'], packet['endpoint'],
-                                                           packet['payload'], packet['publish_id'])
-        for client in self._service_clients:
-            if client.name == service and client.version == version:
-                fun = getattr(client, endpoint)
-                asyncio.async(fun(payload))
-        protocol.send(MessagePacket.ack(publish_id))
 
     def handle_connected(self):
         if self.tcp_host:
@@ -231,7 +220,6 @@ class TCPBus:
 
 
 class PubSubBus:
-    PUBSUB_DELAY = 5
 
     def __init__(self, registry_client, ssl_context=None):
         self._pubsub_handler = None
@@ -246,18 +234,21 @@ class PubSubBus:
 
     def register_for_subscription(self, host, port, node_id, clients):
         self._clients = clients
-        subscription_list = []
-        xsubscription_list = []
+        subs_list = []
+        xsubs_list4registry = []
+        xsubs_list4redis = []
         for client in clients:
             if isinstance(client, TCPServiceClient):
                 for each in dir(client):
                     fn = getattr(client, each)
                     if callable(fn) and getattr(fn, 'is_subscribe', False):
-                        subscription_list.append(self._get_pubsub_key(client.name, client.version, fn.__name__))
+                        subs_list.append(self._get_pubsub_key(client.name, client.version, fn.__name__))
                     elif callable(fn) and getattr(fn, 'is_xsubscribe', False):
-                        xsubscription_list.append((client.name, client.version, fn.__name__, getattr(fn, 'strategy')))
-        self._registry_client.x_subscribe(host, port, node_id, xsubscription_list)
-        yield from self._pubsub_handler.subscribe(subscription_list, handler=self.subscription_handler)
+                        xsubs_list4registry.append((client.name, client.version, fn.__name__, getattr(fn, 'strategy')))
+                        xsubs_list4redis.append(self._get_pubsub_key(client.name, client.version, fn.__name__,
+                                                                     node_id=node_id))
+        self._registry_client.x_subscribe(host, port, node_id, xsubs_list4registry)
+        yield from self._pubsub_handler.subscribe(subs_list + xsubs_list4redis, handler=self.subscription_handler)
 
     def publish(self, service, version, endpoint, payload):
         endpoint_key = self._get_pubsub_key(service, version, endpoint)
@@ -271,36 +262,26 @@ class PubSubBus:
             strategies[(subscriber['service'], subscriber['version'])].append(
                 (subscriber['host'], subscriber['port'], subscriber['node_id'], subscriber['strategy']))
         for key, value in strategies.items():
-            publish_id = str(uuid.uuid4())
-            future = asyncio.async(
-                self._connect_and_publish(publish_id, service, version, endpoint, value, payload))
-            self._pending_publishes[publish_id] = future
-
-    def receive(self, packet, transport, protocol):
-        if packet['type'] == 'ack':
-            future = self._pending_publishes.pop(packet['request_id'], None)
-            if future:
-                future.cancel()
-                transport.close()
+            if value[0][3] == 'LEADER':
+                node_id = value[0][2]
+            else:
+                random_metadata = random.choice(value)
+                node_id = random_metadata[2]
+            endpoint_key = self._get_pubsub_key(service, version, endpoint, node_id=node_id)
+            asyncio.async(self._pubsub_handler.publish(endpoint_key, json.dumps(payload, cls=VykedEncoder)))
 
     def subscription_handler(self, endpoint, payload):
-        service, version, endpoint = endpoint.split('/')
+        elements = endpoint.split('/')
+        if len(elements) > 3:
+            service, version, endpoint, node_id = elements
+        else:
+            service, version, endpoint = elements
         client = [sc for sc in self._clients if (sc.name == service and sc.version == version)][0]
         func = getattr(client, endpoint)
         asyncio.async(func(**json.loads(payload)))
 
     @staticmethod
-    def _get_pubsub_key(service, version, endpoint):
+    def _get_pubsub_key(service, version, endpoint, node_id=None):
+        if node_id:
+            return '/'.join((service, str(version), endpoint, node_id))
         return '/'.join((service, str(version), endpoint))
-
-    def _connect_and_publish(self, publish_id, service, version, endpoint, subscribers, payload):
-        if subscribers[0][3] == 'LEADER':
-            host, port = subscribers[0][0], subscribers[0][1]
-        else:
-            random_metadata = random.choice(subscribers)
-            host, port = random_metadata[0], random_metadata[1]
-        transport, protocol = yield from asyncio.get_event_loop().create_connection(
-            partial(get_vyked_protocol, self), host, port)
-        packet = MessagePacket.publish(publish_id, service, version, endpoint, payload)
-        protocol.send(packet)
-        yield from asyncio.sleep(self.PUBSUB_DELAY)

--- a/vyked/bus.py
+++ b/vyked/bus.py
@@ -271,13 +271,17 @@ class PubSubBus:
 
     def subscription_handler(self, endpoint, payload):
         elements = endpoint.split('/')
+        node_id = None
         if len(elements) > 3:
             service, version, endpoint, node_id = elements
         else:
             service, version, endpoint = elements
         client = [sc for sc in self._clients if (sc.name == service and sc.version == version)][0]
         func = getattr(client, endpoint)
-        asyncio.async(func(**json.loads(payload)))
+        if node_id:
+            asyncio.async(func(json.loads(payload)))
+        else:
+            asyncio.async(func(**json.loads(payload)))
 
     @staticmethod
     def _get_pubsub_key(service, version, endpoint, node_id=None):

--- a/vyked/bus.py
+++ b/vyked/bus.py
@@ -4,7 +4,6 @@ from functools import partial
 import json
 import logging
 import random
-import uuid
 
 from again.utils import unique_hex
 import aiohttp

--- a/vyked/pubsub.py
+++ b/vyked/pubsub.py
@@ -42,11 +42,11 @@ class PubSub:
         """
         if self._conn is not None:
             try:
-                yield from self._conn.publish(endpoint, payload)
-                return True
+                receiving_clients = yield from self._conn.publish(endpoint, payload)
+                return receiving_clients
             except redis.Error as e:
                 self._logger.error('Publish failed with error %s', repr(e))
-        return False
+        return 0
 
     @asyncio.coroutine
     def subscribe(self, endpoints: list, handler):

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -115,10 +115,7 @@ class Repository:
         for name, versions in self._subscribe_list.items():
             for version, endpoints in versions.items():
                 for endpoint, subscribers in endpoints.items():
-                    to_remove = []
-                    for subscriber in subscribers:
-                        if node_id == subscriber[4]:
-                            to_remove.append(subscriber)
+                    to_remove = list(filter(lambda x : node_id == x[4], subscribers))
                     for subscriber in to_remove:
                         subscribers.remove(subscriber)
         for name, nodes in self._uptimes.items():

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -100,15 +100,27 @@ class Repository:
         thehost = None
         for name, versions in self._registered_services.items():
             for version, instances in versions.items():
+                to_remove = []
                 for instance in instances:
                     host, port, node, service_type = instance
                     if node_id == node:
                         thehost = host
-                        instances.remove(instance)
+                        to_remove.append(instance)
                         try:
                             self.remove_pending_instance(name, version, node_id)
                         except ValueError:
                             pass
+                for instance in to_remove:
+                    instances.remove(instance)
+        for name, versions in self._subscribe_list.items():
+            for version, endpoints in versions.items():
+                for endpoint, subscribers in endpoints.items():
+                    to_remove = []
+                    for subscriber in subscribers:
+                        if node_id == subscriber[4]:
+                            to_remove.append(subscriber)
+                    for subscriber in to_remove:
+                        subscribers.remove(subscriber)
         for name, nodes in self._uptimes.items():
             for host, uptimes in nodes.items():
                 if host == thehost and uptimes['node_id'] == node_id:

--- a/vyked/registry_client.py
+++ b/vyked/registry_client.py
@@ -39,6 +39,7 @@ class RegistryClient:
         self._assigned_services = defaultdict(lambda: defaultdict(list))
         self._ssl_context = ssl_context
         self.logger = logging.getLogger(__name__)
+        self._xsubscribe_packet = None
 
     @property
     def conn_handler(self):
@@ -72,7 +73,9 @@ class RegistryClient:
     def x_subscribe(self, host, port, node_id, endpoints):
         packet = ControlPacket.xsubscribe(self._service, self._version, host, port, node_id,
                                           endpoints)
-        self._protocol.send(packet)
+        if not self._xsubscribe_packet:
+            self._protocol.send(packet)
+        self._xsubscribe_packet = packet
 
     @retry(should_retry_for_result=_retry_for_result, should_retry_for_exception=_retry_for_exception,
            strategy=[0, 2, 4, 8, 16, 32])
@@ -81,6 +84,8 @@ class RegistryClient:
                                                                                   self._host, self._port,
                                                                                   ssl=self._ssl_context)
         self.conn_handler.handle_connected()
+        if self._xsubscribe_packet:
+            self._protocol.send(self._xsubscribe_packet)
         if self._pinger:
             self._pinger.stop()
         self._pinger = TCPPinger(self._host, self._port, 'registry', self._protocol, self)


### PR DESCRIPTION
x-subscribe is now handled by Redis, thus it scales well against parallel publishes and saves on connection creation overhead for every publish. 
