### PR TITLE
handle json encoding of UUID strings

### DIFF
--- a/vyked/utils/jsonencoder.py
+++ b/vyked/utils/jsonencoder.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 import datetime
 from time import mktime
 
@@ -15,4 +16,8 @@ class VykedEncoder(json.JSONEncoder):
         """
         if isinstance(obj, datetime.datetime):
             return int(mktime(obj.timetuple()))
+
+        if isinstance(obj, uuid.UUID):
+            return str(obj)
+
         return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
uuids being returned by apis result in an error as the default json encoder does not understand `uuid.UUID`.
