### PR TITLE
Enabled pinging for HTTP Services and added a show_current_state API

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 setuptools>=18.0
 again==1.2.21
-aiohttp>=0.17.0
+aiohttp==0.20.2
 aiopgx==0.7.0
 async-retrial>0.2
 asyncio-redis==0.13.4

--- a/vyked/host.py
+++ b/vyked/host.py
@@ -83,7 +83,7 @@ class Host:
             ssl_context = cls._http_service.ssl_context
             app = Application(loop=asyncio.get_event_loop())
             fn = getattr(cls._http_service, 'pong')
-            app.router.add_route('GET', '/ping', fn)
+            app.router.add_route('GET', '/ping/{node}', fn)
             app.router.add_route('GET', '/_stats', getattr(cls._http_service, 'stats'))
             app.router.add_route('GET', '/_change_log_level/{level}', getattr(cls._http_service, 'handle_log_change'))
             for each in cls._http_service.__ordered__:

--- a/vyked/pinger.py
+++ b/vyked/pinger.py
@@ -102,7 +102,7 @@ class HTTPPinger:
         self._pinger = Pinger(self, PING_INTERVAL, PING_TIMEOUT)
         self._node_id = node_id
         self._handler = handler
-        self._url = 'http://{}:{}/ping'.format(host, port)
+        self._url = 'http://{}:{}/ping/'.format(host, port)
         self.logger = logging.getLogger(__name__)
 
     def ping(self, payload=None):
@@ -113,12 +113,12 @@ class HTTPPinger:
 
     def ping_coroutine(self, payload=None):
         try:
-            res = yield from request('get', self._url)
+            res = yield from request('get', self._url + payload)
             if res.status == 200:
                 self.pong_received(payload=payload)
                 res.close()
         except Exception:
-            self.logger.exception('Error while ping')
+            self.logger.error('Error while pinging')
 
     def stop(self):
         self._pinger.stop()

--- a/vyked/services.py
+++ b/vyked/services.py
@@ -246,9 +246,12 @@ class HTTPService(_ServiceHost, metaclass=OrderedClassMembers):
     def preflight_response(self):
         return self._preflight_response
 
-    @staticmethod
-    def pong(_):
-        return Response()
+    def pong(self, request: Request):
+        node_id = request.match_info.get('node')
+        if node_id == self._node_id:
+            return Response()
+        else:
+            return Response(status=500)
 
     @staticmethod
     def stats(_):

--- a/vyked/utils/log.py
+++ b/vyked/utils/log.py
@@ -17,6 +17,14 @@ BLUE = '\033[94m'
 BOLD = '\033[1m'
 END = '\033[0m'
 
+http_pings_logs_disabled = True
+
+
+def http_ping_filter(record):
+    if "GET /ping/" in record.getMessage():
+       return 0
+    return 1
+
 
 class CustomTimeLoggingFormatter(logging.Formatter):
 
@@ -141,6 +149,10 @@ def setup_logging(_):
     logger.addHandler = patch_add_handler(logger)
 
     logging.config.dictConfig(config_dict)
+
+    if http_pings_logs_disabled:
+        for handler in logging.root.handlers:
+            handler.addFilter(http_ping_filter)
 
 
 def log(fn=None, logger=logging.getLogger(), debug_level=logging.DEBUG):


### PR DESCRIPTION
The Registry will now ping HTTP Services, which will get de-registered if they do not respond. These pings will also have the node_id in the URL and the Services will respond to pings only if their node_id matches the ping node_id. This will ensure that if a service is restarted, it will not respond to pings sent for the instance which was running before. 

In addition to this, a TCP API has been added to the Registry: "show_current_state" which returns a JSON dump of the registered services, pending services and xsubscription list. 
