### PR TITLE
Added support for Amber services and improved statistics

### DIFF
--- a/vyked/bus.py
+++ b/vyked/bus.py
@@ -177,6 +177,8 @@ class TCPBus:
             self._handle_log_change(packet, protocol)
         elif packet['type'] == 'get_tasks':
             protocol.send(len(list(asyncio.Task.all_tasks())))
+        elif packet['type'] == 'get_queues':
+            protocol.send(str([(x._service_name, len(x._pending_requests.keys())) for x in self._service_clients]))
         else:
             if self.tcp_host.is_for_me(packet['service'], packet['version']):
                 func = getattr(self, '_' + packet['type'] + '_receiver')

--- a/vyked/decorators/http.py
+++ b/vyked/decorators/http.py
@@ -39,10 +39,11 @@ def get_decorated_fun(method, path, required_params):
                         res_d = {'error': 'Required params {} not found'.format(','.join(missing_params))}
                         Stats.http_stats['total_responses'] += 1
                         Aggregator.update_stats(endpoint=func.__name__, status=400, success=False,
-                                                server_type='http', time_taken=0)
+                                                server_type='http', time_taken=0, process_time_taken=0)
                         return Response(status=400, content_type='application/json', body=json.dumps(res_d).encode())
 
                 t1 = time.time()
+                tp1 = time.process_time()
                 wrapped_func = func
                 success = True
                 _logger = logging.getLogger()
@@ -73,6 +74,7 @@ def get_decorated_fun(method, path, required_params):
 
                 else:
                     t2 = time.time()
+                    tp2 = time.process_time()
                     hostname = socket.gethostname()
                     service_name = '_'.join(setproctitle.getproctitle().split('_')[:-1])
                     status = result.status
@@ -80,6 +82,7 @@ def get_decorated_fun(method, path, required_params):
                     logd = {
                         'status': result.status,
                         'time_taken': int((t2 - t1) * 1000),
+                        'process_time_taken': int((tp2-tp1) * 1000),
                         'type': 'http',
                         'hostname': hostname, 'service_name': service_name
                     }
@@ -89,8 +92,10 @@ def get_decorated_fun(method, path, required_params):
 
                 finally:
                     t2 = time.time()
+                    tp2 = time.process_time()
                     Aggregator.update_stats(endpoint=func.__name__, status=status, success=success,
-                                            server_type='http', time_taken=int((t2 - t1) * 1000))
+                                            server_type='http', time_taken=int((t2 - t1) * 1000),
+                                            process_time_taken=int((tp2 - tp1) * 1000))
 
         f.is_http_method = True
         f.method = method

--- a/vyked/decorators/tcp.py
+++ b/vyked/decorators/tcp.py
@@ -114,6 +114,7 @@ def _get_api_decorator(func=None, old_api=None, replacement_api=None):
     def wrapper(*args, **kwargs):
         _logger = logging.getLogger(__name__)
         start_time = int(time.time() * 1000)
+        start_process_time = int(time.process_time() * 1000)
         self = args[0]
         rid = kwargs.pop('request_id')
         entity = kwargs.pop('entity')
@@ -159,6 +160,7 @@ def _get_api_decorator(func=None, old_api=None, replacement_api=None):
             Stats.tcp_stats['total_responses'] += 1
 
         end_time = int(time.time() * 1000)
+        end_process_time = int(time.process_time() * 1000)
 
         hostname = socket.gethostname()
         service_name = '_'.join(setproctitle.getproctitle().split('_')[:-1])
@@ -173,7 +175,8 @@ def _get_api_decorator(func=None, old_api=None, replacement_api=None):
 
         # call to update aggregator, designed to replace the stats module.
         Aggregator.update_stats(endpoint=func.__name__, status=status, success=success,
-                                server_type='tcp', time_taken=end_time - start_time)
+                                server_type='tcp', time_taken=end_time - start_time,
+                                process_time_taken=start_process_time - end_process_time)
 
         if not old_api:
             return self._make_response_packet(request_id=rid, from_id=from_id, entity=entity, result=result,

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -293,7 +293,7 @@ class Registry:
     def _inform_consumers(self, service: Service):
         consumers = self._repository.get_consumers(service.name, service.version)
         for service_name, service_version, _ in consumers:
-            if not self._repository.is_pending(service_name, service_version):
+            # if not self._repository.is_pending(service_name, service_version):
                 instances = self._repository.get_instances(service_name, service_version)
                 for host, port, node, stype in instances:
                     protocol = self._client_protocols[node]
@@ -318,8 +318,8 @@ class Registry:
                     if not len(tcp_instances):
                         should_activate = False
                         break
+                self._send_activated_packet(service, version, node)
                 if should_activate:
-                    self._send_activated_packet(service, version, node)
                     self._repository.remove_pending_instance(service, version, node)
                     self.logger.info('%s activated', (service, version))
                 else:

--- a/vyked/registry_client.py
+++ b/vyked/registry_client.py
@@ -116,7 +116,7 @@ class RegistryClient:
 
     def get_all_addresses(self, name, version):
         return self._available_services.get(
-            self._get_full_service_name(name, version))
+            self._get_full_service_name(name, version), [])
 
     def get_for_node(self, node_id):
         for services in self._available_services.values():
@@ -157,7 +157,7 @@ class RegistryClient:
     def cache_vendors(self, vendors):
         for vendor in vendors:
             vendor_name = self._get_full_service_name(vendor['name'], vendor['version'])
-            for address in vendor['addresses']:
+            for address in vendor.get('addresses', []):
                 vendor_entry = (address['host'], address['port'], address['node_id'], address['type'])
                 if vendor_entry not in self._available_services[vendor_name]:
                     self._available_services[vendor_name].append(


### PR DESCRIPTION
Now, a service can serve requests, even if not all its dependencies are active.
Also, now only successful requests are taken into account when computing the average response time. 
Also, added a new key: "average_process_time" in the statistics, to get an idea of CPU utilization. 
