### PR TITLE
Handling the case where someone might add our delimiter to data

### DIFF
--- a/vyked/__init__.py
+++ b/vyked/__init__.py
@@ -13,4 +13,4 @@ from .exceptions import RequestException, VykedServiceError, VykedServiceExcepti
 from .utils.log import setup_logging  # noqa
 from .wrappers import Response, Request  # noqa
 
-__version__ = '2.2.9'
+__version__ = '2.3.0'

--- a/vyked/jsonprotocol.py
+++ b/vyked/jsonprotocol.py
@@ -67,15 +67,17 @@ class JSONProtocol(asyncio.Protocol):
             pass
             try:
                 string_data = self._partial_data + string_data
-                self._partial_data = ''
+                partial_data = ''
                 for e in string_data.split('!<^>!'):
                     if e:
                         try:
-                            element = json.loads(e)
+                            element = json.loads(partial_data + e)
+                            partial_data = ''
                             self.on_element(element)
                         except Exception as exc:
-                            self._partial_data = e
+                            partial_data += e
                             self.logger.debug('Packet splitting: %s', self._partial_data)
+                self._partial_data = partial_data
             except Exception as e:
                 self.logger.error('Could not parse data: %s', string_data)
             # self._obj_streamer.consume(string_data)


### PR DESCRIPTION
If someone adds our vyked delimiter '!<^>!' in a string, our services communication will fail. Have handled it now.