### PR TITLE
Registry new endpoint for removing service manually from XSubscription List

### DIFF
--- a/vyked/__init__.py
+++ b/vyked/__init__.py
@@ -13,4 +13,4 @@ from .exceptions import RequestException, VykedServiceError, VykedServiceExcepti
 from .utils.log import setup_logging  # noqa
 from .wrappers import Response, Request  # noqa
 
-__version__ = '2.4.0'
+__version__ = '2.4.1'

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -146,7 +146,7 @@ class Repository:
     def xsubscribe(self, service, version, host, port, node_id, endpoints):
         entry = (service, version)
         # Remove all entries of service, version from subscribe list
-        self._remove_service_from_xsubscribe(service, version)
+        self.remove_service_from_xsubscribe(service, version)
 
         # Add entries of service, version into subscribe list - thus keeping
         # only the latest information
@@ -182,7 +182,7 @@ class Repository:
     def _split_key(key: str):
         return tuple(key.split('/'))
 
-    def _remove_service_from_xsubscribe(self, service, version):
+    def remove_service_from_xsubscribe(self, service, version):
         for name, versions in self._subscribe_list.items():
             for p_version, endpoints2 in versions.items():
                 for endpoint, subscribers in endpoints2.items():
@@ -507,7 +507,7 @@ class Registry:
         
     def _remove_service_from_xsubscribe(self, packet, protocol):
         params = packet['params']
-        self._repository._remove_service_from_xsubscribe(params['service'], params['version'])
+        self._repository.remove_service_from_xsubscribe(params['service'], params['version'])
         protocol.send("Successfully Removed " + str(params['service']) + ":" + str(params['version']) + " from XSubscription list.")
 
 if __name__ == '__main__':

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -507,7 +507,7 @@ class Registry:
         
     def _remove_service_from_xsubscribe(self, packet, protocol):
         params = packet['params']
-        self._repository.remove_service_from_xsubscribe(params['service'], params['version'])
+        self._repository.remove_service_from_xsubscribe(params['service'].lower(), params['version'])
         protocol.send("Successfully Removed " + str(params['service']) + ":" + str(params['version']) + " from XSubscription list.")
 
 if __name__ == '__main__':

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -504,7 +504,7 @@ class Registry:
                        'XSubscription List': self._repository._subscribe_list,
                        'Service Dependencies': self._repository._service_dependencies}
         protocol.send(status_dict)
-g
+        
     def _remove_service_from_xsubscribe(self, packet, protocol):
         params = packet['params']
         self._repository._remove_service_from_xsubscribe(params['service'], params['version'])

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -155,7 +155,7 @@ class Repository:
                 entry)
 
     def get_subscribers(self, service, version, endpoint):
-         return self._subscribe_list[service][version][endpoint]
+        return self._subscribe_list[service][version][endpoint]
 
     def _get_non_breaking_version(self, version, versions):
         if version in versions:
@@ -504,7 +504,7 @@ class Registry:
                        'XSubscription List': self._repository._subscribe_list,
                        'Service Dependencies': self._repository._service_dependencies}
         protocol.send(status_dict)
-
+g
     def _remove_service_from_xsubscribe(self, packet, protocol):
         params = packet['params']
         self._repository._remove_service_from_xsubscribe(params['service'], params['version'])

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -506,8 +506,9 @@ class Registry:
         protocol.send(status_dict)
 
     def _remove_service_from_xsubscribe(self, packet, protocol):
-        self._repository._remove_service_from_xsubscribe(packet['service'], packet['version'])
-        protocol.send("Successfully Removed " + str(packet['service']) + ":" + str(packet['version']) + " from XSubscription list.")
+        params = packet['params']
+        self._repository._remove_service_from_xsubscribe(params['service'], params['version'])
+        protocol.send("Successfully Removed " + str(params['service']) + ":" + str(params['version']) + " from XSubscription list.")
 
 if __name__ == '__main__':
     # config_logs(enable_ping_logs=False, log_level=logging.DEBUG)

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -161,7 +161,14 @@ class Repository:
                 entry)
 
     def get_subscribers(self, service, version, endpoint):
-        return self._subscribe_list[service][version][endpoint]
+        subscribers = []
+        for subscriber in self._subscribe_list[service][version][endpoint]:
+            subscriber_service = subscriber[0]
+            subscriber_version = subscriber[1]
+            if self._registered_services[subscriber_service][subscriber_version]:
+                subscribers.append(subscriber)
+
+        return subscribers
 
     def _get_non_breaking_version(self, version, versions):
         if version in versions:

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -146,29 +146,16 @@ class Repository:
     def xsubscribe(self, service, version, host, port, node_id, endpoints):
         entry = (service, version)
         # Remove all entries of service, version from subscribe list
-        for name, versions in self._subscribe_list.items():
-            for p_version, endpoints2 in versions.items():
-                for endpoint, subscribers in endpoints2.items():
-                    to_remove = list(filter(lambda x: service == x[0] and version == x[1], 
-                        subscribers))
-                    for subscriber in to_remove:
-                        subscribers.remove(subscriber)
+        self._remove_service_from_xsubscribe(service, version)
 
-        # Add entries of service, version into subscribe list - thus keeping 
+        # Add entries of service, version into subscribe list - thus keeping
         # only the latest information
         for endpoint in endpoints:
             self._subscribe_list[endpoint['service']][endpoint['version']][endpoint['endpoint']].append(
                 entry)
 
     def get_subscribers(self, service, version, endpoint):
-        subscribers = []
-        for subscriber in self._subscribe_list[service][version][endpoint]:
-            subscriber_service = subscriber[0]
-            subscriber_version = subscriber[1]
-            if self._registered_services[subscriber_service][subscriber_version]:
-                subscribers.append(subscriber)
-
-        return subscribers
+         return self._subscribe_list[service][version][endpoint]
 
     def _get_non_breaking_version(self, version, versions):
         if version in versions:
@@ -194,6 +181,15 @@ class Repository:
     @staticmethod
     def _split_key(key: str):
         return tuple(key.split('/'))
+
+    def _remove_service_from_xsubscribe(self, service, version):
+        for name, versions in self._subscribe_list.items():
+            for p_version, endpoints2 in versions.items():
+                for endpoint, subscribers in endpoints2.items():
+                    to_remove = list(filter(lambda x: service == x[0] and version == x[1],
+                                            subscribers))
+                    for subscriber in to_remove:
+                        subscribers.remove(subscriber)
 
 
 class Registry:
@@ -270,6 +266,8 @@ class Registry:
             self._show_blacklisted(protocol)
         elif request_type == 'show_current_state':
             self._show_current_state(protocol)
+        elif request_type == 'remove_service_from_xsubscribe':
+            self._remove_service_from_xsubscribe(packet, protocol)
 
     def deregister_service(self, host, port, node_id):
         service = self._repository.get_node(node_id)
@@ -506,6 +504,10 @@ class Registry:
                        'XSubscription List': self._repository._subscribe_list,
                        'Service Dependencies': self._repository._service_dependencies}
         protocol.send(status_dict)
+
+    def _remove_service_from_xsubscribe(self, packet, protocol):
+        self._repository._remove_service_from_xsubscribe(packet['service'], packet['version'])
+        protocol.send("Successfully Removed " + str(packet['service']) + ":" + str(packet['version']) + " from XSubscription list.")
 
 if __name__ == '__main__':
     # config_logs(enable_ping_logs=False, log_level=logging.DEBUG)


### PR DESCRIPTION
Removing service only from the Xsubscription List based on service name and version but later can be added to remove it from registered instances list (leaving that functionality same).
